### PR TITLE
Fixed typo Triffen->Triffin

### DIFF
--- a/collections/_writings/triffin-dilemma.md
+++ b/collections/_writings/triffin-dilemma.md
@@ -1,6 +1,6 @@
 ---
 layout: writing
-title: Triffen Dilemma
+title: Triffin Dilemma
 date: 1111-11-11
 categories: ['Money']
 author: ['Wikipedia']


### PR DESCRIPTION
From the name of the Belgian-American economist Robert Triffin: https://en.wikipedia.org/wiki/Robert_Triffin